### PR TITLE
Homework 7: GraphQL

### DIFF
--- a/src/components/modals/ModalTrackUpload.tsx
+++ b/src/components/modals/ModalTrackUpload.tsx
@@ -69,13 +69,10 @@ export default function ModalTrackUpload({
   const onSubmit = (data: FormData) => {
     setOpen(ModalStateSchema.Enum.closed);
 
-    const formData = new FormData();
-    formData.append('file', data.file);
-
     toast.promise(
       uploadFile({
         trackId: track.id,
-        formData,
+        file: data.file,
       }),
       {
         loading: <span data-testid="toast-loading">Uploading...</span>,

--- a/src/services/graphql.ts
+++ b/src/services/graphql.ts
@@ -1,0 +1,192 @@
+import {
+  CreateTrackDto,
+  QueryParams,
+  Track,
+  TracksResponse,
+  UpdateTrackDto,
+} from '@/types';
+import api from '@/lib/axios';
+
+export const getTracks = async (
+  params?: QueryParams
+): Promise<TracksResponse> => {
+  const query = /* GraphQL */ `
+    query Tracks($params: TracksQueryParams) {
+      tracks(params: $params) {
+        data {
+          id
+          title
+          artist
+          album
+          genres
+          slug
+          coverImage
+          audioFile
+          createdAt
+          updatedAt
+        }
+        meta {
+          total
+          page
+          limit
+          totalPages
+        }
+      }
+    }
+  `;
+
+  const response = await api.post<{ tracks: TracksResponse }>('/graphql', {
+    query,
+    variables: { params },
+  });
+
+  return response.data.tracks;
+};
+
+export const createTrack = async (data: CreateTrackDto) => {
+  const query = /* GraphQL */ `
+    mutation AddTrack($data: AddTrackInput) {
+      addTrack(data: $data) {
+        id
+        title
+        artist
+        album
+        genres
+        slug
+        coverImage
+        createdAt
+        updatedAt
+      }
+    }
+  `;
+
+  const response = await api.post<{ addTrack: Track }>('/graphql', {
+    query,
+    variables: { data },
+  });
+
+  return response.data.addTrack;
+};
+
+export const updateTrack = async (id: string, data: UpdateTrackDto) => {
+  const query = /* GraphQL */ `
+    mutation UpdateTrack($id: ID, $data: UpdateTrackInput) {
+      updateTrack(id: $id, data: $data) {
+        id
+        title
+        artist
+        album
+        genres
+        slug
+        coverImage
+        audioFile
+        createdAt
+        updatedAt
+      }
+    }
+  `;
+
+  const response = await api.post<{ updateTrack: Track }>('/graphql', {
+    query,
+    variables: { id, data },
+  });
+
+  return response.data.updateTrack;
+};
+
+export const deleteTrack = async (id: string) => {
+  const query = /* GraphQL */ `
+    mutation DeleteTrack($id: ID) {
+      deleteTrack(id: $id)
+    }
+  `;
+
+  const response = await api.post<{ deleteTrack: boolean }>('/graphql', {
+    query,
+    variables: { id },
+  });
+
+  return response.data.deleteTrack;
+};
+
+export const deleteTrackFile = async (id: string) => {
+  const query = /* GraphQL */ `
+    mutation DeleteTrackFile($id: ID) {
+      deleteTrackFile(id: $id) {
+        id
+        title
+        artist
+        album
+        genres
+        slug
+        coverImage
+        audioFile
+        createdAt
+        updatedAt
+      }
+    }
+  `;
+
+  const response = await api.post<{ deleteTrackFile: boolean }>('/graphql', {
+    query,
+    variables: { id },
+  });
+
+  return response.data.deleteTrackFile;
+};
+
+export const uploadTrackFile = async (id: string, file: File) => {
+  const formData = new FormData();
+
+  formData.append(
+    'operations',
+    JSON.stringify({
+      query: `
+        mutation UploadTrackFile($id: ID, $file: Upload) {
+          uploadTrackFile(id: $id, file: $file) {
+            id
+            title
+            artist
+            album
+            genres
+            slug
+            coverImage
+            audioFile
+            createdAt
+            updatedAt
+          }
+        }
+      `,
+      variables: {
+        id,
+        file: null,
+      },
+    })
+  );
+
+  formData.append('map', JSON.stringify({ '0': ['variables.file'] }));
+
+  formData.append('0', file);
+
+  const response = await api.post('/graphql', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data.uploadTrackFile;
+};
+
+export const getGenres = async () => {
+  const query = /* GraphQL */ `
+    query Genres {
+      genres
+    }
+  `;
+
+  const response = await api.post<{ genres: string[] }>('/graphql', {
+    query,
+  });
+
+  return response.data.genres;
+};

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -12,19 +12,19 @@ import {
   UpdateTrackDto,
 } from '@/types';
 import {
+  getTracks,
   createTrack,
+  updateTrack,
   deleteTrack,
   deleteTrackFile,
-  getGenres,
-  getTracks,
-  updateTrack,
   uploadTrackFile,
-} from './index';
+  getGenres,
+} from './graphql';
 
 export const useTracks = (params?: Partial<QueryParams>) => {
   return useQuery<TracksResponse>({
     queryKey: ['tracks', params],
-    queryFn: () => getTracks({ ...params }),
+    queryFn: () => getTracks(params),
     placeholderData: keepPreviousData,
   });
 };
@@ -70,14 +70,8 @@ export const useGenres = () => {
 
 export const useUploadTrackFile = () => {
   return useMutation({
-    mutationFn: async ({
-      trackId,
-      formData,
-    }: {
-      trackId: string;
-      formData: FormData;
-    }) => {
-      return uploadTrackFile(trackId, formData);
+    mutationFn: async ({ trackId, file }: { trackId: string; file: File }) => {
+      return uploadTrackFile(trackId, file);
     },
   });
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -30,7 +30,10 @@ export const deleteTrack = async (id: string) => {
 
 export const getGenres = (): Promise<string[]> => api.get('/genres');
 
-export const uploadTrackFile = (trackId: string, formData: FormData) => {
+export const uploadTrackFile = (trackId: string, file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
   return api.post(`/tracks/${trackId}/upload`, formData, {
     headers: {
       'Content-Type': 'multipart/form-data',


### PR DESCRIPTION
Changes

- Migrated track-related API calls from REST to GraphQL.
- Added a new src/services/graphql.ts file implementing all track and genre operations (fetch, create, update, delete, upload, etc.) using GraphQL queries and mutations.
- Updated React Query hooks in src/services/hooks.ts to use the new GraphQL service functions.
- Refactored file upload logic to work with GraphQL mutations and the appropriate multipart request format.